### PR TITLE
Modernize codebase with Svelte 5 features

### DIFF
--- a/.changeset/empty-dolls-stare.md
+++ b/.changeset/empty-dolls-stare.md
@@ -1,0 +1,5 @@
+---
+"neogrok": patch
+---
+
+Minimize number of unknown language in syntax highlighting

--- a/.changeset/silent-singers-fix.md
+++ b/.changeset/silent-singers-fix.md
@@ -1,0 +1,5 @@
+---
+"neogrok": patch
+---
+
+Disallow setting the `repos` form field to 0, as that's nonsense

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Commands
+
+- **Build:** `yarn build`
+- **Dev server:** `yarn dev`
+- **Lint (full):** `yarn lint` (runs svelte-check, prettier --check, eslint)
+- **Typecheck:** `yarn svelte-kit sync && yarn svelte-check --tsconfig ./tsconfig.json --fail-on-warnings`
+- **Test all:** `yarn test`
+- **Test single file:** `yarn vitest run <path>` (e.g. `yarn vitest run src/lib/url-templates.test.ts`)
+- **Format:** `yarn format`
+
+## Architecture
+
+SvelteKit app (Svelte 5, adapter-node) — a code search frontend for [zoekt](https://github.com/sourcegraph/zoekt). Uses Tailwind CSS 4, TypeScript (strict mode), and Vite. Routes are in `src/routes/`; shared components and utilities are in `src/lib/`. Server-side code (zoekt client, API helpers) lives in `src/lib/server/`. Schema validation uses `@badrap/valita`. Tests are co-located with source files as `*.test.ts` and use vitest.
+
+## Code Style
+
+- Package manager: **yarn** (v4, Corepack). Never use npm.
+- Formatting: Prettier (default config + prettier-plugin-svelte). No semicolons omission — use defaults.
+- Imports: bare specifiers for deps, `$lib/` alias for `src/lib/`. No file extensions on TS imports.
+- Types: strict TS (`strict: true`). No `any` unless unavoidable. Use `@badrap/valita` for runtime validation.
+- Naming: kebab-case filenames, camelCase variables/functions.
+- Components: Svelte 5 (runes). `.svelte` files in `src/lib/` or route dirs.
+- No code comments explaining obvious logic; comments should explain _why_, not _what_.
+- Prefer arrow functions over the `function` keyword.
+- Always use braces with conditionals or loops.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -7,6 +7,7 @@ import globals from "globals";
 import { fileURLToPath } from "node:url";
 import ts from "typescript-eslint";
 const gitignorePath = fileURLToPath(new URL("./.gitignore", import.meta.url));
+import svelteConfig from "./svelte.config.js";
 
 export default defineConfig(
   includeIgnoreFile(gitignorePath),
@@ -47,11 +48,13 @@ export default defineConfig(
     },
   },
   {
-    files: ["**/*.svelte"],
-
+    files: ["**/*.svelte", "**/*.svelte.ts", "**/*.svelte.js"],
     languageOptions: {
       parserOptions: {
+        projectService: true,
+        extraFileExtensions: [".svelte"],
         parser: ts.parser,
+        svelteConfig,
       },
     },
   },

--- a/src/lib/doc-section-heading.svelte
+++ b/src/lib/doc-section-heading.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
-  export let id: string;
-  export let element: "h2" | "h3" | "caption" = "h2";
+  type Props = {
+    id: string;
+    element?: "h2" | "h3" | "caption";
+    children: import("svelte").Snippet;
+  };
+
+  let { id, element = "h2", children }: Props = $props();
 </script>
 
 <svelte:element
@@ -11,6 +16,6 @@
   class:pb-2={element === "caption"}
 >
   <a href={`#${id}`} class="hover:underline">
-    <slot />
+    {@render children()}
   </a>
 </svelte:element>

--- a/src/lib/example-query.svelte
+++ b/src/lib/example-query.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import Link from "./link.svelte";
   import Expression from "./expression.svelte";
-  export let query: string;
-  export let wrap = false;
-  export let page: "search" | "repositories" = "search";
+  type Props = {
+    query: string;
+    wrap?: boolean;
+    page?: "search" | "repositories";
+  };
+
+  let { query, wrap = false, page = "search" }: Props = $props();
 </script>
 
 <Link

--- a/src/lib/expression.svelte
+++ b/src/lib/expression.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-  export let wrap = false;
+  type Props = {
+    wrap?: boolean;
+    children: import("svelte").Snippet;
+  };
+
+  let { wrap = false, children }: Props = $props();
 </script>
 
 <code
   class="bg-gray-100 dark:bg-gray-800 p-1 text-sm"
   class:whitespace-pre-wrap={wrap}
-  class:whitespace-nowrap={!wrap}><slot /></code
+  class:whitespace-nowrap={!wrap}>{@render children()}</code
 >

--- a/src/lib/integer-input.svelte
+++ b/src/lib/integer-input.svelte
@@ -1,30 +1,38 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import { computeInputColor } from "$lib/input-colors";
 
-  export let value: number;
-  export let kind: "nonnegative" | "positive" = "nonnegative";
-  export let size = 3;
-  export let id: string;
-  export let pending: boolean;
+  type Props = {
+    value: number;
+    kind?: "nonnegative" | "positive";
+    size?: number;
+    id: string;
+    pending: boolean;
+    onChange?: (value: number) => void;
+  };
 
-  const dispatch = createEventDispatcher<{ change: number }>();
+  let {
+    value = $bindable(),
+    kind = "nonnegative",
+    size = 3,
+    id,
+    pending,
+    onChange,
+  }: Props = $props();
 
-  let stringValue = value.toString();
-  let valid = true;
-
-  $: {
-    valid =
-      /^\d+$/.test(stringValue) &&
-      (kind === "nonnegative" || stringValue !== "0");
+  let stringValue = $state(value.toString());
+  let valid = $derived(
+    /^\d+$/.test(stringValue) &&
+      (kind === "nonnegative" || stringValue !== "0"),
+  );
+  $effect(() => {
     if (valid) {
       const parsed = Number.parseInt(stringValue, 10);
       if (value !== parsed) {
         value = parsed;
-        dispatch("change", parsed);
+        onChange?.(parsed);
       }
     }
-  }
+  });
 </script>
 
 <input

--- a/src/lib/link.svelte
+++ b/src/lib/link.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-  export let to: string;
+  type Props = {
+    to: string;
+    children: import("svelte").Snippet;
+  };
+
+  let { to, children }: Props = $props();
 </script>
 
 <a
   class="text-cyan-700 dark:text-cyan-400 hover:underline decoration-1"
   href={to}
 >
-  <slot />
+  {@render children()}
 </a>

--- a/src/lib/loading-ellipsis.svelte
+++ b/src/lib/loading-ellipsis.svelte
@@ -1,19 +1,15 @@
 <script lang="ts">
-  import { navigating } from "$app/stores";
-  import { derived } from "svelte/store";
+  import { navigating } from "$app/state";
 
-  const count = derived<typeof navigating, number>(
-    navigating,
-    ($n, set, update) => {
-      if ($n !== null) {
-        const id = setInterval(() => update((c) => c + 1), 250);
-        return () => clearInterval(id);
-      } else {
-        set(0);
-      }
-    },
-    0,
-  );
+  let count = $state(0);
+  $effect(() => {
+    if (navigating.type !== null) {
+      const id = setInterval(() => count++, 250);
+      return () => clearInterval(id);
+    } else {
+      count = 0;
+    }
+  });
 </script>
 
-{".".repeat($count % 4)}
+{".".repeat(count % 4)}

--- a/src/lib/preferences.svelte.ts
+++ b/src/lib/preferences.svelte.ts
@@ -1,6 +1,5 @@
 import type { Cookies } from "@sveltejs/kit";
 import { getContext, setContext } from "svelte";
-import { writable, type Writable } from "svelte/store";
 
 export type SearchType = "live" | "manual";
 const searchTypeKey = "searchType";
@@ -40,8 +39,8 @@ export type Preferences = {
 };
 
 /**
- * Called during server load to parse cookies into Preferences, which can then
- * be used as Data during both SSR and CSR.
+ * Parses server cookies into Preferences, which can then be used as Data during
+ * both SSR and CSR.
  */
 export const loadPreferences = (cookies: Cookies): Preferences => ({
   [searchTypeKey]: loadPreference(
@@ -91,44 +90,65 @@ const loadPreference = <T>(
   }
 };
 
-/**
- * Called during page component initialization to create the relevant stores.
- */
-export const persistInitialPreferences = (preferences: Preferences) => {
-  Object.entries(preferences).forEach(([k, v]) =>
-    setContext(k, createPreferenceStore(k, v)),
+/** Exposes Preferences as reactive state for usage in components. Pushes writes into browser cookies. */
+export class PreferencesState {
+  #searchType: SearchType = $state(defaultSearchType);
+  #matchSortOrder: MatchSortOrder = $state(defaultMatchSortOrder);
+  #fileMatchesCutoff: FileMatchesCutoff = $state(defaultFileMatchesCutoff);
+  #openGrokInstantRedirect: OpenGrokInstantRedirect = $state(
+    defaultOpenGrokInstantRedirect,
   );
+
+  constructor(initial: Preferences) {
+    this.#searchType = initial.searchType;
+    this.#matchSortOrder = initial.matchSortOrder;
+    this.#fileMatchesCutoff = initial.fileMatchesCutoff;
+    this.#openGrokInstantRedirect = initial.openGrokInstantRedirect;
+  }
+
+  get searchType() {
+    return this.#searchType;
+  }
+  set searchType(v: SearchType) {
+    this.#searchType = v;
+    writeCookie(searchTypeKey, v);
+  }
+
+  get matchSortOrder() {
+    return this.#matchSortOrder;
+  }
+  set matchSortOrder(v: MatchSortOrder) {
+    this.#matchSortOrder = v;
+    writeCookie(matchSortOrderKey, v);
+  }
+
+  get fileMatchesCutoff() {
+    return this.#fileMatchesCutoff;
+  }
+  set fileMatchesCutoff(v: FileMatchesCutoff) {
+    this.#fileMatchesCutoff = v;
+    writeCookie(fileMatchesCutoffKey, v);
+  }
+
+  get openGrokInstantRedirect() {
+    return this.#openGrokInstantRedirect;
+  }
+  set openGrokInstantRedirect(v: OpenGrokInstantRedirect) {
+    this.#openGrokInstantRedirect = v;
+    writeCookie(openGrokInstantRedirectKey, v);
+  }
+}
+
+const writeCookie = (key: string, val: string | number | boolean) => {
+  document.cookie = `${key}=${val};path=/;sameSite=lax`;
 };
 
-const createPreferenceStore = <T>(
-  key: string,
-  initialValue: T,
-): Writable<T> => {
-  const delegate = writable(initialValue);
-  return {
-    subscribe: (...args) => delegate.subscribe(...args),
-    set: (val) => {
-      // We are counting on all keys and values being valid cookie keys/values,
-      // without escaping.
-      document.cookie = `${key}=${val};path=/;sameSite=lax`;
-      delegate.set(val);
-    },
-    update: () => {
-      throw new Error(`unimplemented`);
-    },
-  };
+const prefsCtx = Symbol("preferences");
+
+/** Transmutes raw Preferences data into contextually available PreferencesState. */
+export const contextifyPreferences = (initial: Preferences) => {
+  setContext(prefsCtx, new PreferencesState(initial));
 };
 
-// These are functions that can be called during component initialization to get
-// stores that work on CSR and SSR. We use context for this to mitigate
-// SvelteKit's abominable store semantics on SSR:
-// https://github.com/sveltejs/kit/discussions/4339
-export const acquireSearchTypeStore = (): Writable<SearchType> =>
-  getContext(searchTypeKey);
-export const acquireMatchSortOrderStore = (): Writable<MatchSortOrder> =>
-  getContext(matchSortOrderKey);
-export const acquireFileMatchesCutoffStore = (): Writable<FileMatchesCutoff> =>
-  getContext(fileMatchesCutoffKey);
-export const acquireOpenGrokInstantRedirectStore =
-  (): Writable<OpenGrokInstantRedirect> =>
-    getContext(openGrokInstantRedirectKey);
+/** Retrieves contextually available PreferencesState. */
+export const usePreferences = (): PreferencesState => getContext(prefsCtx);

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,12 +1,3 @@
-import { readonly, writable } from "svelte/store";
+import { MediaQuery } from "svelte/reactivity";
 
-export type BrowserTheme = "light" | "dark";
-
-const query =
-  "matchMedia" in globalThis ? matchMedia("(prefers-color-scheme:dark)") : null;
-const writableTheme = writable<BrowserTheme>(query?.matches ? "dark" : "light");
-query?.addEventListener("change", (event) => {
-  writableTheme.set(event.matches ? "dark" : "light");
-});
-
-export const browserTheme = readonly(writableTheme);
+export const prefersDark = new MediaQuery("prefers-color-scheme:dark");

--- a/src/lib/toggle-match-sort-order.svelte
+++ b/src/lib/toggle-match-sort-order.svelte
@@ -14,7 +14,7 @@
   title={$matchSortOrder === "line-number"
     ? "sort matches by score"
     : "sort matches by line number"}
-  on:click={() => {
+  onclick={() => {
     $matchSortOrder =
       $matchSortOrder === "line-number" ? "score" : "line-number";
   }}

--- a/src/lib/toggle-match-sort-order.svelte
+++ b/src/lib/toggle-match-sort-order.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-  import { acquireMatchSortOrderStore } from "$lib/preferences";
+  import { usePreferences } from "$lib/preferences.svelte";
   import ListOrdered from "lucide-svelte/icons/list-ordered";
 
-  const matchSortOrder = acquireMatchSortOrderStore();
+  const prefs = usePreferences();
 </script>
 
 <button
   class={`border-[1.5px] rounded w-6 grid place-items-center ${
-    $matchSortOrder === "line-number"
+    prefs.matchSortOrder === "line-number"
       ? "text-cyan-600 dark:text-cyan-400 border-cyan-600 dark:border-cyan-400"
       : "border-dashed border-black dark:border-white"
   }`}
-  title={$matchSortOrder === "line-number"
+  title={prefs.matchSortOrder === "line-number"
     ? "sort matches by score"
     : "sort matches by line number"}
   onclick={() => {
-    $matchSortOrder =
-      $matchSortOrder === "line-number" ? "score" : "line-number";
+    prefs.matchSortOrder =
+      prefs.matchSortOrder === "line-number" ? "score" : "line-number";
   }}
 >
   <ListOrdered class="inline" size={18} strokeWidth={1.5} />

--- a/src/lib/toggle-search-type.svelte
+++ b/src/lib/toggle-search-type.svelte
@@ -12,7 +12,7 @@
       : "border-dashed border-black dark:border-white"
   }`}
   title={$searchType === "live" ? "disable live search" : "enable live search"}
-  on:click={() => {
+  onclick={() => {
     $searchType = $searchType === "live" ? "manual" : "live";
   }}
 >

--- a/src/lib/toggle-search-type.svelte
+++ b/src/lib/toggle-search-type.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
-  import { acquireSearchTypeStore } from "$lib/preferences";
+  import { usePreferences } from "$lib/preferences.svelte";
   import Zap from "lucide-svelte/icons/zap";
 
-  const searchType = acquireSearchTypeStore();
+  const prefs = usePreferences();
 </script>
 
 <button
   class={`border-[1.5px] rounded w-6 grid place-items-center ${
-    $searchType === "live"
+    prefs.searchType === "live"
       ? "text-cyan-600 dark:text-cyan-400 border-cyan-600 dark:border-cyan-400"
       : "border-dashed border-black dark:border-white"
   }`}
-  title={$searchType === "live" ? "disable live search" : "enable live search"}
+  title={prefs.searchType === "live"
+    ? "disable live search"
+    : "enable live search"}
   onclick={() => {
-    $searchType = $searchType === "live" ? "manual" : "live";
+    prefs.searchType = prefs.searchType === "live" ? "manual" : "live";
   }}
 >
   <Zap class="inline" size={18} strokeWidth={1.5} />

--- a/src/routes/(opengrok-compat)/+layout.svelte
+++ b/src/routes/(opengrok-compat)/+layout.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import Link from "$lib/link.svelte";
   import { acquireOpenGrokInstantRedirectStore } from "$lib/preferences";
+  type Props = {
+    children: import("svelte").Snippet;
+  };
+
+  let { children }: Props = $props();
 
   const openGrokInstantRedirect = acquireOpenGrokInstantRedirectStore();
 </script>
@@ -20,7 +25,7 @@
       and zoekt ought to be much faster and easier to use.
     </p>
   </section>
-  <slot />
+  {@render children()}
   <section class="space-y-2 max-w-prose mx-auto">
     <h2 class="text-lg">Want to get instantly redirected next time?</h2>
     <label class="text-sm">

--- a/src/routes/(opengrok-compat)/+layout.svelte
+++ b/src/routes/(opengrok-compat)/+layout.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import Link from "$lib/link.svelte";
-  import { acquireOpenGrokInstantRedirectStore } from "$lib/preferences";
+  import { usePreferences } from "$lib/preferences.svelte";
   type Props = {
     children: import("svelte").Snippet;
   };
 
   let { children }: Props = $props();
 
-  const openGrokInstantRedirect = acquireOpenGrokInstantRedirectStore();
+  const prefs = usePreferences();
 </script>
 
 <svelte:head>
@@ -29,9 +29,9 @@
   <section class="space-y-2 max-w-prose mx-auto">
     <h2 class="text-lg">Want to get instantly redirected next time?</h2>
     <label class="text-sm">
-      <input type="checkbox" bind:checked={$openGrokInstantRedirect} /> Redirect
-      me from old OpenGrok URLs automatically when possible. (You can undo this
-      on the <Link to="/preferences">preferences page</Link>.)</label
+      <input type="checkbox" bind:checked={prefs.openGrokInstantRedirect} />
+      Redirect me from old OpenGrok URLs automatically when possible. (You can undo
+      this on the <Link to="/preferences">preferences page</Link>.)</label
     >
   </section>
 </div>

--- a/src/routes/(opengrok-compat)/diff/[project]/[...file]/+page.svelte
+++ b/src/routes/(opengrok-compat)/diff/[project]/[...file]/+page.svelte
@@ -3,7 +3,11 @@
   import Link from "$lib/link.svelte";
   import { escapeRegExp } from "$lib/regexp";
 
-  export let data: import("./$types").PageData;
+  type Props = {
+    data: import("./$types").PageData;
+  };
+
+  const { data }: Props = $props();
 </script>
 
 <section class="space-y-2 pt-2 max-w-prose mx-auto">

--- a/src/routes/(opengrok-compat)/download/[project]/[...file]/+page.svelte
+++ b/src/routes/(opengrok-compat)/download/[project]/[...file]/+page.svelte
@@ -3,7 +3,11 @@
   import Link from "$lib/link.svelte";
   import { escapeRegExp } from "$lib/regexp";
 
-  export let data: import("./$types").PageData;
+  type Props = {
+    data: import("./$types").PageData;
+  };
+
+  let { data }: Props = $props();
 </script>
 
 <section class="space-y-2 pt-2 max-w-prose mx-auto">

--- a/src/routes/(opengrok-compat)/history/[project]/[...file]/+page.svelte
+++ b/src/routes/(opengrok-compat)/history/[project]/[...file]/+page.svelte
@@ -3,7 +3,11 @@
   import Link from "$lib/link.svelte";
   import { escapeRegExp } from "$lib/regexp";
 
-  export let data: import("./$types").PageData;
+  type Props = {
+    data: import("./$types").PageData;
+  };
+
+  let { data }: Props = $props();
 </script>
 
 <section class="space-y-2 pt-2 max-w-prose mx-auto">

--- a/src/routes/(opengrok-compat)/raw/[project]/[...file]/+page.svelte
+++ b/src/routes/(opengrok-compat)/raw/[project]/[...file]/+page.svelte
@@ -3,7 +3,11 @@
   import Link from "$lib/link.svelte";
   import { escapeRegExp } from "$lib/regexp";
 
-  export let data: import("./$types").PageData;
+  type Props = {
+    data: import("./$types").PageData;
+  };
+
+  let { data }: Props = $props();
 </script>
 
 <section class="space-y-2 pt-2 max-w-prose mx-auto">

--- a/src/routes/(opengrok-compat)/search/+page.svelte
+++ b/src/routes/(opengrok-compat)/search/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import SearchQueryConversion from "./search-query-conversion.svelte";
 
-  export let data: import("./$types").PageData;
+  type Props = {
+    data: import("./$types").PageData;
+  };
+
+  let { data }: Props = $props();
 </script>
 
 <SearchQueryConversion

--- a/src/routes/(opengrok-compat)/search/search-query-conversion.svelte
+++ b/src/routes/(opengrok-compat)/search/search-query-conversion.svelte
@@ -8,47 +8,51 @@
     type ZoektConversionWarning,
   } from "./conversion-warnings";
 
-  export let openGrokParams: { readonly [key: string]: unknown };
-  export let luceneQuery: string | null;
-  export let zoektQuery: string | null;
-  export let warnings: ReadonlyArray<ZoektConversionWarning>;
+  type Props = {
+    openGrokParams: { readonly [key: string]: unknown };
+    luceneQuery: string | null;
+    zoektQuery: string | null;
+    warnings: ReadonlyArray<ZoektConversionWarning>;
+  };
 
-  let highlightedLocation: QueryLocation | null = null;
+  let { openGrokParams, luceneQuery, zoektQuery, warnings }: Props = $props();
 
-  $: renderedWarnings = warnings.map(renderWarning);
+  let highlightedLocation: QueryLocation | null = $state(null);
+
+  let renderedWarnings = $derived(warnings.map(renderWarning));
 
   type QueryToken =
     | { kind: "normal"; content: string }
     | { kind: "highlighted"; content: string };
 
-  let renderedLuceneQuery: ReadonlyArray<QueryToken> | null;
+  let renderedLuceneQuery: ReadonlyArray<QueryToken> | null = $derived.by(
+    () => {
+      if (highlightedLocation && luceneQuery) {
+        return [
+          {
+            kind: "normal",
+            content: luceneQuery.slice(0, highlightedLocation.start),
+          },
 
-  $: {
-    if (highlightedLocation && luceneQuery) {
-      renderedLuceneQuery = [
-        {
-          kind: "normal",
-          content: luceneQuery.slice(0, highlightedLocation.start),
-        },
-
-        {
-          kind: "highlighted",
-          content: luceneQuery.slice(
-            highlightedLocation.start,
-            highlightedLocation.end,
-          ),
-        },
-        {
-          kind: "normal",
-          content: luceneQuery.slice(highlightedLocation.end),
-        },
-      ];
-    } else if (luceneQuery) {
-      renderedLuceneQuery = [{ kind: "normal", content: luceneQuery }];
-    } else {
-      renderedLuceneQuery = null;
-    }
-  }
+          {
+            kind: "highlighted",
+            content: luceneQuery.slice(
+              highlightedLocation.start,
+              highlightedLocation.end,
+            ),
+          },
+          {
+            kind: "normal",
+            content: luceneQuery.slice(highlightedLocation.end),
+          },
+        ];
+      } else if (luceneQuery) {
+        return [{ kind: "normal", content: luceneQuery }];
+      } else {
+        return null;
+      }
+    },
+  );
 </script>
 
 <section class="space-y-2">
@@ -126,12 +130,12 @@
           {#each renderedWarnings as { message, location }}
             <li
               class="text-sm"
-              on:mouseenter={() => {
+              onmouseenter={() => {
                 if (location) {
                   highlightedLocation = location;
                 }
               }}
-              on:mouseleave={() => {
+              onmouseleave={() => {
                 highlightedLocation = null;
               }}
             >

--- a/src/routes/(opengrok-compat)/xref/[project]/[...file]/+page.svelte
+++ b/src/routes/(opengrok-compat)/xref/[project]/[...file]/+page.svelte
@@ -3,7 +3,11 @@
   import Link from "$lib/link.svelte";
   import { escapeRegExp } from "$lib/regexp";
 
-  export let data: import("./$types").PageData;
+  type Props = {
+    data: import("./$types").PageData;
+  };
+
+  let { data }: Props = $props();
 </script>
 
 <section class="space-y-2 pt-2 max-w-prose mx-auto">

--- a/src/routes/(search-page)/+page.svelte
+++ b/src/routes/(search-page)/+page.svelte
@@ -1,28 +1,36 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import type { SearchResults as ApiSearchResults } from "$lib/server/search-api";
   import SearchForm from "./search-form.svelte";
   import Lander from "./lander.svelte";
   import SearchResults from "./search-results.svelte";
-  import { routeSearchQuery } from "./route-search-query";
+  import { parseSearchParams } from "./route-search-query";
 
-  export let data: import("./$types").PageData;
+  let routeSearchQuery = $derived(parseSearchParams(page.url.searchParams));
+
+  type Props = {
+    data: import("./$types").PageData;
+  };
+
+  let { data }: Props = $props();
 
   // Represents the last non-erroneous results, so that when we get an error,
   // we can display them instead of taking away all the results.
-  let previousSearchResults: ApiSearchResults | null = null;
-  $: {
+  let previousSearchResults: ApiSearchResults | null = $derived.by(() => {
     if (data.searchOutcome.kind === "success") {
-      previousSearchResults = data.searchOutcome.results;
+      return data.searchOutcome.results;
     } else if (data.searchOutcome.kind === "none") {
-      previousSearchResults = null;
+      return null;
+    } else {
+      return previousSearchResults;
     }
-  }
+  });
 </script>
 
 <svelte:head>
   <title
-    >{$routeSearchQuery.query
-      ? `${$routeSearchQuery.query} - `
+    >{routeSearchQuery.query
+      ? `${routeSearchQuery.query} - `
       : ""}neogrok</title
   >
 </svelte:head>

--- a/src/routes/(search-page)/line-group.svelte
+++ b/src/routes/(search-page)/line-group.svelte
@@ -6,8 +6,12 @@
   import type { LineGroup } from "./chunk-renderer";
   import RenderedContent from "./rendered-content.svelte";
 
-  export let lines: LineGroup;
-  export let file: ResultFile;
+  type Props = {
+    lines: LineGroup;
+    file: ResultFile;
+  };
+
+  let { lines, file }: Props = $props();
 
   // Syntax highlighting can be pretty CPU intensive and so is done just in
   // time, and only on the client.
@@ -24,8 +28,9 @@
   // to everything else in the app. The baseline shiki bundle (their JS, the
   // oniguruma wasm blob, plus the theme we use) is something like 300kb
   // _gzipped_, and each language is 3-50 more.
-  let visible = false;
-  let highlights: undefined | ReadonlyArray<ReadonlyArray<ThemedToken>>;
+  let visible = $state(false);
+  let highlights: undefined | ReadonlyArray<ReadonlyArray<ThemedToken>> =
+    $state.raw();
 
   const highlight = async (code: string, theme: BrowserTheme) => {
     // We dynamically import shiki itself because it's huge and won't be
@@ -52,7 +57,6 @@
       const lang = language as BundledLanguage;
       // It's worth checking again, as downloading that chunk can take a
       // while, and highlighting can occupy meaningful CPU time.
-      // eslint-disable-next-line svelte/infinite-reactive-loop
       highlights = (
         await codeToTokens(code, {
           theme: `github-${theme}`,
@@ -70,7 +74,7 @@
     }
   };
 
-  $: {
+  $effect(() => {
     if (visible) {
       // Skip highlighting anything with long lines, as it's an excellent way to
       // freeze the browser. Such files are probably minified web assets, or
@@ -78,7 +82,6 @@
       if (!lines.some(({ line }) => line.text.length >= 1000)) {
         // Shiki only accepts a single string even though it goes
         // right ahead and splits it :(.
-        // eslint-disable-next-line svelte/infinite-reactive-loop
         highlight(
           lines.map(({ line: { text } }) => text).join("\n"),
           $browserTheme,
@@ -87,10 +90,12 @@
         // We can have defined `highlights` here if our LineGroup was cut in two
         // by a now-removed "hidden" threshold. Having highlights for part of
         // the group but not the rest is strange in the UI, so remove it all.
+
+        // TODO verify this situation is reachable still in svelte 5 :thonk:
         highlights = undefined;
       }
     }
-  }
+  });
 
   let visibilityCanary: Element;
   onMount(() => {

--- a/src/routes/(search-page)/line-group.svelte
+++ b/src/routes/(search-page)/line-group.svelte
@@ -47,10 +47,65 @@
     // different lineages, we have no hope but to do some remappings. TODO
     // perhaps these should be upstreamed as aliases in shikiji.
     switch (language) {
-      case "restructuredtext":
-        return "rst";
+      case "1c enterprise":
+        return "1c";
+      case "actionscript":
+        return "actionscript-3";
+      case "apacheconf":
+        return "apache";
+      case "assembly":
+        return "asm";
+      case "batchfile":
+        return "bat";
+      case "closure templates":
+        return "closure-templates";
+      case "common lisp":
+        return "common-lisp";
+      case "dm":
+        return "dream-maker";
+      case "emacs lisp":
+        return "emacs-lisp";
+      case "fortran":
+      case "fortran free form":
+        return "fortran-free-form";
+      case "gettext catalog":
+        return "po";
+      case "git commit":
+        return "git-commit";
+      case "glimmer js":
+        return "glimmer-js";
+      case "glimmer ts":
+        return "glimmer-ts";
+      case "godot resource":
+        return "gdresource";
+      case "html+erb":
+        return "erb";
+      case "json with comments":
+        return "jsonc";
+      case "lean 4":
+        return "lean4";
+      case "objective-c++":
+        return "objective-cpp";
       case "protocol buffer":
         return "protobuf";
+      case "regular expression":
+        return "regexp";
+      case "restructuredtext":
+        return "rst";
+      case "ros interface":
+        return "rosmsg";
+      case "ssh config":
+        return "ssh-config";
+      case "systemverilog":
+        return "system-verilog";
+      case "vim script":
+        return "viml";
+      case "visual basic .net":
+        return "vb";
+      case "webassembly":
+        return "wasm";
+      case "wolfram language":
+        return "wolfram";
       default:
         return language;
     }

--- a/src/routes/(search-page)/line-group.svelte
+++ b/src/routes/(search-page)/line-group.svelte
@@ -34,35 +34,50 @@
   // oniguruma wasm blob, plus the theme we use) is something like 300kb
   // _gzipped_, and each language is 3-50 more.
   let visible = $state(false);
-  let highlights: undefined | ReadonlyArray<ReadonlyArray<ThemedToken>> =
-    $state.raw();
+  let highlights = $state.raw<
+    ReadonlyArray<ReadonlyArray<ThemedToken>> | undefined
+  >();
 
-  const highlight = async (code: string, theme: BrowserTheme) => {
-    // We dynamically import shiki itself because it's huge and won't be
-    // needed by those landing on the home page with no search query, or
-    // on the server at all.
-    const { codeToTokens, bundledLanguages } = await import("shiki");
-
+  const toTextmateLanguage = (linguistLanguage: string): string => {
     // This is the same normalization that zoekt applies when querying
     // go-enry, and it seems to be good enough for us querying shiki as well.
-    let language = file.language.toLowerCase();
+    const language = linguistLanguage.toLowerCase();
     // ... except when it isn't. go-enry (backed by linguist) and shiki
     // (backed by vscode's textmate grammars) just seem to have fundamentally
     // different lineages, we have no hope but to do some remappings. TODO
     // perhaps these should be upstreamed as aliases in shikiji.
-    if (language === "restructuredtext") {
-      language = "rst";
-    } else if (language === "protocol buffer") {
-      language = "protobuf";
+    switch (language) {
+      case "restructuredtext":
+        return "rst";
+      case "protocol buffer":
+        return "protobuf";
+      default:
+        return language;
+    }
+  };
+
+  const computeHighlights = async (
+    lines: ReadonlyArray<string>,
+    language: string,
+    theme: BrowserTheme,
+    signal: AbortSignal,
+  ): Promise<typeof highlights> => {
+    // We dynamically import shiki itself because it's huge and won't be
+    // needed by those landing on the home page with no search query, or
+    // on the server at all.
+    const { codeToTokens, bundledLanguages } = await import("shiki");
+    if (signal.aborted) {
+      return;
     }
 
     if (language in bundledLanguages) {
       // I guess TS isn't interested in doing this refinement based on the
       // check above.
       const lang = language as BundledLanguage;
-      // It's worth checking again, as downloading that chunk can take a
-      // while, and highlighting can occupy meaningful CPU time.
-      highlights = (
+      // Shiki only accepts a single string even though it goes right ahead and
+      // splits it :(.
+      const code = lines.join("\n");
+      return (
         await codeToTokens(code, {
           theme: `github-${theme}`,
           lang,
@@ -78,40 +93,46 @@
   };
 
   $effect(() => {
-    if (visible) {
-      // Skip highlighting anything with long lines, as it's an excellent way to
-      // freeze the browser. Such files are probably minified web assets, or
-      // otherwise low-signal.
-      if (!lines.some(({ line }) => line.text.length >= 1000)) {
-        // Shiki only accepts a single string even though it goes
-        // right ahead and splits it :(.
-        highlight(
-          lines.map(({ line: { text } }) => text).join("\n"),
-          browserTheme,
-        );
-      } else {
-        // We can have defined `highlights` here if our LineGroup was cut in two
-        // by a now-removed "hidden" threshold. Having highlights for part of
-        // the group but not the rest is strange in the UI, so remove it all.
-
-        // TODO verify this situation is reachable still in svelte 5 :thonk:
-        highlights = undefined;
-      }
+    if (!visible) {
+      return;
     }
+
+    // Skip highlighting anything with long lines, as it's an excellent way to
+    // freeze the browser. Such files are probably minified web assets, or
+    // otherwise low-signal.
+    if (lines.some(({ line }) => line.text.length >= 1000)) {
+      highlights = undefined;
+      return;
+    }
+
+    // Capture current reactive values for this run.
+    const language = toTextmateLanguage(file.language);
+    const theme = browserTheme;
+
+    const abortController = new AbortController();
+    computeHighlights(
+      lines.map(({ line: { text } }) => text),
+      language,
+      theme,
+      abortController.signal,
+    ).then((tokens) => {
+      if (!abortController.signal.aborted) {
+        highlights = tokens;
+      }
+    });
+    return () => abortController.abort();
   });
 
   let visibilityCanary: Element;
   onMount(() => {
-    const observer = new IntersectionObserver(async (entries) => {
+    const observer = new IntersectionObserver((entries) => {
       if (entries.some(({ isIntersecting }) => isIntersecting)) {
         observer.disconnect();
         visible = true;
       }
     });
     observer.observe(visibilityCanary);
-    return () => {
-      observer.disconnect();
-    };
+    return () => observer.disconnect();
   });
 </script>
 

--- a/src/routes/(search-page)/line-group.svelte
+++ b/src/routes/(search-page)/line-group.svelte
@@ -2,7 +2,7 @@
   import type { ResultFile } from "$lib/server/search-api";
   import { onMount } from "svelte";
   import type { ThemedToken, BundledLanguage } from "shiki";
-  import { browserTheme, type BrowserTheme } from "$lib/theme";
+  import { prefersDark } from "$lib/theme";
   import type { LineGroup } from "./chunk-renderer";
   import RenderedContent from "./rendered-content.svelte";
 
@@ -12,6 +12,11 @@
   };
 
   let { lines, file }: Props = $props();
+
+  type BrowserTheme = "light" | "dark";
+  const browserTheme: BrowserTheme = $derived(
+    prefersDark.current ? "dark" : "light",
+  );
 
   // Syntax highlighting can be pretty CPU intensive and so is done just in
   // time, and only on the client.
@@ -64,8 +69,6 @@
         })
       ).tokens;
     } else if (language !== "text") {
-      // TODO this will be a lot of console spam... could use a store, as
-      // absurd as that is.
       console.warn(
         "Could not find shiki language for '%s', skipping highlighting",
         language,
@@ -84,7 +87,7 @@
         // right ahead and splits it :(.
         highlight(
           lines.map(({ line: { text } }) => text).join("\n"),
-          $browserTheme,
+          browserTheme,
         );
       } else {
         // We can have defined `highlights` here if our LineGroup was cut in two

--- a/src/routes/(search-page)/rendered-content.svelte
+++ b/src/routes/(search-page)/rendered-content.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
   import type { ContentLine, Range } from "$lib/server/content-parser";
 
-  export let content: ContentLine;
-  export let highlights: ReadonlyArray<ThemedToken> | undefined = undefined;
   import type { ThemedToken } from "shiki";
   import type { FontStyle } from "@shikijs/vscode-textmate";
+
+  type Props = {
+    content: ContentLine;
+    highlights?: ReadonlyArray<ThemedToken> | undefined;
+  };
+
+  let { content, highlights = undefined }: Props = $props();
 
   const toFontClass = (
     fontStyle: FontStyle | undefined,
@@ -34,9 +39,7 @@
     match: boolean;
     color?: string;
     fontClass?: string;
-  }>;
-
-  $: {
+  }> = $derived.by(() => {
     const t: typeof tokens = [];
     if (highlights) {
       // If highlights are present, its spans have full coverage, so we can just
@@ -115,8 +118,8 @@
         t.push({ text: content.text.slice(base), match: false });
       }
     }
-    tokens = t;
-  }
+    return t;
+  });
 </script>
 
 <!-- eslint-disable-next-line svelte/require-each-key -->

--- a/src/routes/(search-page)/route-search-query.ts
+++ b/src/routes/(search-page)/route-search-query.ts
@@ -1,6 +1,6 @@
 import { goto } from "$app/navigation";
 import { page, navigating } from "$app/state";
-import type { SearchType } from "$lib/preferences";
+import type { SearchType } from "$lib/preferences.svelte";
 import type { SearchQuery } from "$lib/server/search-api";
 
 const defaultQueryOptions: Omit<SearchQuery, "query"> = Object.freeze({

--- a/src/routes/(search-page)/route-search-query.ts
+++ b/src/routes/(search-page)/route-search-query.ts
@@ -1,8 +1,7 @@
-import { derived, get } from "svelte/store";
+import { goto } from "$app/navigation";
+import { page, navigating } from "$app/state";
 import type { SearchType } from "$lib/preferences";
 import type { SearchQuery } from "$lib/server/search-api";
-import { page, navigating } from "$app/stores";
-import { goto } from "$app/navigation";
 
 const defaultQueryOptions: Omit<SearchQuery, "query"> = Object.freeze({
   contextLines: 1,
@@ -10,7 +9,7 @@ const defaultQueryOptions: Omit<SearchQuery, "query"> = Object.freeze({
   matches: 500,
 });
 
-type RouteSearchQuery = Omit<SearchQuery, "query"> & {
+export type RouteSearchQuery = Omit<SearchQuery, "query"> & {
   readonly query: string | undefined;
 };
 
@@ -41,10 +40,6 @@ export const parseSearchParams = (
   };
 };
 
-export const routeSearchQuery = derived(page, (p) =>
-  parseSearchParams(p.url.searchParams),
-);
-
 // This function is only called in the browser, so it's fine to have this be in
 // module state.
 let lastNavigateTime = 0;
@@ -67,7 +62,7 @@ export const updateRouteSearchQuery = ({
   // that we need to use the URL of where we're _going_ to be, not where we are,
   // as a baseline for comparison to decide if additional navigations are
   // needed.
-  const baselineUrl = get(navigating)?.to?.url ?? get(page).url;
+  const baselineUrl = navigating.to?.url ?? page.url;
   const searchQuery = parseSearchParams(baselineUrl.searchParams);
 
   const queryChanged =

--- a/src/routes/(search-page)/search-form.svelte
+++ b/src/routes/(search-page)/search-form.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { navigating, page } from "$app/state";
-  import { acquireSearchTypeStore, type SearchType } from "$lib/preferences";
+  import { usePreferences, type SearchType } from "$lib/preferences.svelte";
   import IntegerInput from "$lib/integer-input.svelte";
   import { computeInputColor } from "$lib/input-colors";
   import ToggleSearchType from "$lib/toggle-search-type.svelte";
@@ -19,7 +19,7 @@
 
   let { queryError = null }: Props = $props();
 
-  const searchType = acquireSearchTypeStore();
+  const prefs = usePreferences();
 
   // We need to do a complicated bidirectional mapping between the URL and the
   // form state. So, yes, this is intentional.
@@ -41,23 +41,25 @@
     }
   });
 
-  const shouldLiveSearch = () =>
-    $searchType === "live" &&
-    // Zoekt search is based on trigrams. Queries for 1 or 2 characters are thus
-    // _really_ expensive on large instances, as they essentially can't use the index
-    // fully. It's also almost always the case that users do not want to make
-    // such short queries, and that such queries are being executed only because
-    // live search is creating them as users type in their desired longer query.
-    //
-    // So, force such queries into a "surprise manual" mode: they will not be
-    // automatically executed, but can still be submitted with the enter key,
-    // just like manual searches.
-    //
-    // Of course, without actually parsing the query (which we will never do, in
-    // neogrok; the zoekt parser is so janky that there's no way it could be
-    // maintainably reimplemented), we can't determine when a user is clearing
-    // the "trigram threshold". This is just a dumb heuristic.
-    (!query || query.length >= 3);
+  let shouldLiveSearch = $derived(
+    prefs.searchType === "live" &&
+      // Zoekt search is based on trigrams. Queries for 1 or 2 characters are
+      // thus _really_ expensive on large instances, as they essentially can't
+      // use the index fully. It's also almost always the case that users do not
+      // want to make such short queries, and that such queries are being
+      // executed only because live search is creating them as users type in
+      // their desired longer query.
+      //
+      // So, force such queries into a "surprise manual" mode: they will not be
+      // automatically executed, but can still be submitted with the enter key,
+      // just like manual searches.
+      //
+      // Of course, without actually parsing the query (which we will never do,
+      // in neogrok; the zoekt parser is so janky that there's no way it could
+      // be maintainably reimplemented), we can't determine when a user is
+      // clearing the "trigram threshold". This is just a dumb heuristic.
+      (!query || query.length >= 3),
+  );
 
   const manualSubmit = () => {
     updateRouteSearchQuery({
@@ -65,17 +67,17 @@
       contextLines,
       files,
       matches,
-      searchType: $searchType,
+      searchType: prefs.searchType,
     });
   };
 
   // When switching from manual to live search, submit any pending changes.
   let previousSearchType: SearchType | undefined = $state();
   $effect(() => {
-    if ($searchType === "live" && previousSearchType === "manual") {
+    if (prefs.searchType === "live" && previousSearchType === "manual") {
       manualSubmit();
     }
-    previousSearchType = $searchType;
+    previousSearchType = prefs.searchType;
   });
 
   // These all indicate when form changes with manual search are not yet submitted.
@@ -122,8 +124,8 @@
         <input
           bind:value={query}
           oninput={() => {
-            if (shouldLiveSearch()) {
-              updateRouteSearchQuery({ query, searchType: $searchType });
+            if (shouldLiveSearch) {
+              updateRouteSearchQuery({ query, searchType: prefs.searchType });
             }
           }}
           id="query"
@@ -146,10 +148,10 @@
         pending={contextLinesPending}
         bind:value={contextLines}
         onChange={(value) => {
-          if (shouldLiveSearch()) {
+          if (shouldLiveSearch) {
             updateRouteSearchQuery({
               contextLines: value,
-              searchType: $searchType,
+              searchType: prefs.searchType,
             });
           }
         }}
@@ -163,10 +165,10 @@
         pending={filesPending}
         bind:value={files}
         onChange={(value) => {
-          if (shouldLiveSearch()) {
+          if (shouldLiveSearch) {
             updateRouteSearchQuery({
               files: value,
-              searchType: $searchType,
+              searchType: prefs.searchType,
             });
           }
         }}
@@ -180,10 +182,10 @@
         pending={matchesPending}
         bind:value={matches}
         onChange={(value) => {
-          if (shouldLiveSearch()) {
+          if (shouldLiveSearch) {
             updateRouteSearchQuery({
               matches: value,
-              searchType: $searchType,
+              searchType: prefs.searchType,
             });
           }
         }}

--- a/src/routes/(search-page)/search-form.svelte
+++ b/src/routes/(search-page)/search-form.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
-  import { navigating } from "$app/stores";
+  import { navigating, page } from "$app/state";
   import { acquireSearchTypeStore, type SearchType } from "$lib/preferences";
   import IntegerInput from "$lib/integer-input.svelte";
   import { computeInputColor } from "$lib/input-colors";
@@ -8,28 +7,39 @@
   import ToggleMatchSortOrder from "$lib/toggle-match-sort-order.svelte";
   import LoadingEllipsis from "$lib/loading-ellipsis.svelte";
   import {
-    routeSearchQuery,
+    parseSearchParams,
     updateRouteSearchQuery,
   } from "./route-search-query";
 
-  export let queryError: string | null = null;
+  let routeSearchQuery = $derived(parseSearchParams(page.url.searchParams));
+
+  type Props = {
+    queryError?: string | null;
+  };
+
+  let { queryError = null }: Props = $props();
 
   const searchType = acquireSearchTypeStore();
 
-  let query: string | undefined;
-  let contextLines: number;
-  let files: number;
-  let matches: number;
-  const unsubscribe = routeSearchQuery.subscribe((rq) => {
+  // We need to do a complicated bidirectional mapping between the URL and the
+  // form state. So, yes, this is intentional.
+  // svelte-ignore state_referenced_locally
+  let query: string | undefined = $state(routeSearchQuery.query);
+  // svelte-ignore state_referenced_locally
+  let contextLines: number = $state(routeSearchQuery.contextLines);
+  // svelte-ignore state_referenced_locally
+  let files: number = $state(routeSearchQuery.files);
+  // svelte-ignore state_referenced_locally
+  let matches: number = $state(routeSearchQuery.matches);
+  $effect(() => {
     // Sync route state into form values upon a navigation _not_ related to
     // direct user interactions with the form. Those are inherently already
     // covered by the relevant input bindings, and the resulting navigations
     // can conflict with those bindings.
-    if ($navigating?.type !== "goto") {
-      ({ query, contextLines, files, matches } = rq);
+    if (navigating.type !== "goto") {
+      ({ query, contextLines, files, matches } = routeSearchQuery);
     }
   });
-  onDestroy(unsubscribe);
 
   const shouldLiveSearch = () =>
     $searchType === "live" &&
@@ -60,27 +70,34 @@
   };
 
   // When switching from manual to live search, submit any pending changes.
-  let previousSearchType: SearchType | undefined;
-  $: {
+  let previousSearchType: SearchType | undefined = $state();
+  $effect(() => {
     if ($searchType === "live" && previousSearchType === "manual") {
       manualSubmit();
     }
     previousSearchType = $searchType;
-  }
+  });
 
   // These all indicate when form changes with manual search are not yet submitted.
-  $: queryPending =
-    $navigating === null && ($routeSearchQuery.query ?? "") !== (query ?? "");
-  $: contextLinesPending =
-    $navigating === null && $routeSearchQuery.contextLines !== contextLines;
-  $: filesPending = $navigating === null && $routeSearchQuery.files !== files;
-  $: matchesPending =
-    $navigating === null && $routeSearchQuery.matches !== matches;
+  let queryPending = $derived(
+    navigating.type === null &&
+      (routeSearchQuery.query ?? "") !== (query ?? ""),
+  );
+  let contextLinesPending = $derived(
+    navigating.type === null && routeSearchQuery.contextLines !== contextLines,
+  );
+  let filesPending = $derived(
+    navigating.type === null && routeSearchQuery.files !== files,
+  );
+  let matchesPending = $derived(
+    navigating.type === null && routeSearchQuery.matches !== matches,
+  );
 </script>
 
 <!-- TODO explore JS-disabled compat.  Should actually be pretty doable with `action="/"`? -->
 <form
-  on:submit|preventDefault={() => {
+  onsubmit={(e) => {
+    e.preventDefault();
     manualSubmit();
   }}
 >
@@ -101,10 +118,10 @@
         )}`}
       >
         <!-- It's a search page, a11y be damned. cf. google.com, bing.com, etc. -->
-        <!-- svelte-ignore a11y-autofocus -->
+        <!-- svelte-ignore a11y_autofocus -->
         <input
           bind:value={query}
-          on:input={() => {
+          oninput={() => {
             if (shouldLiveSearch()) {
               updateRouteSearchQuery({ query, searchType: $searchType });
             }
@@ -128,10 +145,10 @@
         id="context"
         pending={contextLinesPending}
         bind:value={contextLines}
-        on:change={(e) => {
+        onChange={(value) => {
           if (shouldLiveSearch()) {
             updateRouteSearchQuery({
-              contextLines: e.detail,
+              contextLines: value,
               searchType: $searchType,
             });
           }
@@ -145,10 +162,10 @@
         kind="positive"
         pending={filesPending}
         bind:value={files}
-        on:change={(e) => {
+        onChange={(value) => {
           if (shouldLiveSearch()) {
             updateRouteSearchQuery({
-              files: e.detail,
+              files: value,
               searchType: $searchType,
             });
           }
@@ -162,10 +179,10 @@
         kind="positive"
         pending={matchesPending}
         bind:value={matches}
-        on:change={(e) => {
+        onChange={(value) => {
           if (shouldLiveSearch()) {
             updateRouteSearchQuery({
-              matches: e.detail,
+              matches: value,
               searchType: $searchType,
             });
           }

--- a/src/routes/(search-page)/search-results-file-header.svelte
+++ b/src/routes/(search-page)/search-results-file-header.svelte
@@ -6,10 +6,14 @@
   import type { ResultFile } from "$lib/server/search-api";
   import RenderedContent from "./rendered-content.svelte";
 
-  export let file: ResultFile;
-  export let rank: number;
+  type Props = {
+    file: ResultFile;
+    rank: number;
+  };
 
-  $: metadata = [
+  let { file, rank }: Props = $props();
+
+  let metadata = $derived([
     `${file.matchCount} ${file.matchCount === 1 ? "match" : "matches"}`,
     // I don't like every result just yelling HEAD, it's not particularly useful
     // information.
@@ -18,7 +22,7 @@
       : []),
     file.language || "Text",
     `№${rank}`,
-  ];
+  ]);
 </script>
 
 <h2

--- a/src/routes/(search-page)/search-results-file.svelte
+++ b/src/routes/(search-page)/search-results-file.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import {
-    acquireFileMatchesCutoffStore,
-    acquireMatchSortOrderStore,
-  } from "$lib/preferences";
+  import { usePreferences } from "$lib/preferences.svelte";
   import type { ResultFile } from "$lib/server/search-api";
   import SearchResultsFileHeader from "./search-results-file-header.svelte";
   import LineGroup from "./line-group.svelte";
@@ -15,11 +12,10 @@
 
   let { file, rank }: Props = $props();
 
-  const matchSortOrder = acquireMatchSortOrderStore();
-  const fileMatchesCutoff = acquireFileMatchesCutoffStore();
+  const prefs = usePreferences();
 
   let sortedChunks = $derived(
-    $matchSortOrder === "line-number"
+    prefs.matchSortOrder === "line-number"
       ? [...file.chunks].sort(
           ({ startLineNumber: a }, { startLineNumber: b }) => a - b,
         )
@@ -29,7 +25,7 @@
 
   let expanded = $state(false);
   let { lineGroups, preCutoffMatchCount } = $derived(
-    renderChunksToLineGroups(sortedChunks, $fileMatchesCutoff, expanded),
+    renderChunksToLineGroups(sortedChunks, prefs.fileMatchesCutoff, expanded),
   );
 
   let postCutoffMatchCount = $derived(

--- a/src/routes/(search-page)/search-results-file.svelte
+++ b/src/routes/(search-page)/search-results-file.svelte
@@ -8,29 +8,33 @@
   import LineGroup from "./line-group.svelte";
   import { renderChunksToLineGroups } from "./chunk-renderer";
 
-  export let file: ResultFile;
-  export let rank: number;
+  type Props = {
+    file: ResultFile;
+    rank: number;
+  };
+
+  let { file, rank }: Props = $props();
 
   const matchSortOrder = acquireMatchSortOrderStore();
   const fileMatchesCutoff = acquireFileMatchesCutoffStore();
 
-  $: sortedChunks =
+  let sortedChunks = $derived(
     $matchSortOrder === "line-number"
       ? [...file.chunks].sort(
           ({ startLineNumber: a }, { startLineNumber: b }) => a - b,
         )
       : // Nothing to do otherwise; matches are already sorted by score.
-        file.chunks;
+        file.chunks,
+  );
 
-  let expanded = false;
-  $: ({ lineGroups, preCutoffMatchCount } = renderChunksToLineGroups(
-    sortedChunks,
-    $fileMatchesCutoff,
-    expanded,
-  ));
+  let expanded = $state(false);
+  let { lineGroups, preCutoffMatchCount } = $derived(
+    renderChunksToLineGroups(sortedChunks, $fileMatchesCutoff, expanded),
+  );
 
-  $: postCutoffMatchCount =
-    file.matchCount - preCutoffMatchCount - file.fileName.matchRanges.length;
+  let postCutoffMatchCount = $derived(
+    file.matchCount - preCutoffMatchCount - file.fileName.matchRanges.length,
+  );
 
   const expand = () => {
     expanded = true;
@@ -72,7 +76,7 @@
     {#if postCutoffMatchCount > 0 && !expanded}
       <button
         type="button"
-        on:click={expand}
+        onclick={expand}
         class="bg-slate-100 dark:bg-slate-800 text-sm py-1"
       >
         Show {postCutoffMatchCount} more {postCutoffMatchCount === 1
@@ -82,7 +86,7 @@
     {:else if postCutoffMatchCount > 0 && expanded}
       <button
         type="button"
-        on:click={collapse}
+        onclick={collapse}
         class="bg-slate-100 dark:bg-slate-800 text-sm py-1 sticky bottom-0"
       >
         Hide {postCutoffMatchCount}

--- a/src/routes/(search-page)/search-results.svelte
+++ b/src/routes/(search-page)/search-results.svelte
@@ -1,20 +1,31 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import type { SearchResults } from "$lib/server/search-api";
-  import { routeSearchQuery } from "./route-search-query";
+  import { parseSearchParams } from "./route-search-query";
   import SearchResultsFile from "./search-results-file.svelte";
 
-  export let results: SearchResults;
-  $: ({
+  let routeSearchQuery = $derived(parseSearchParams(page.url.searchParams));
+
+  type Props = {
+    results: SearchResults;
+  };
+
+  let { results }: Props = $props();
+  let {
     zoektStats: { fileCount, matchCount, filesSkipped, duration },
     files,
-  } = results);
-  $: neogrokMatchCount = files.reduce((n, { matchCount: m }) => n + m, 0);
+  } = $derived(results);
+  let neogrokMatchCount = $derived(
+    files.reduce((n, { matchCount: m }) => n + m, 0),
+  );
 
-  $: filesLimited =
-    fileCount > files.length && files.length === $routeSearchQuery.files;
-  $: matchesLimited =
+  let filesLimited = $derived(
+    fileCount > files.length && files.length === routeSearchQuery.files,
+  );
+  let matchesLimited = $derived(
     matchCount > neogrokMatchCount &&
-    neogrokMatchCount === $routeSearchQuery.matches;
+      neogrokMatchCount === routeSearchQuery.matches,
+  );
 </script>
 
 <h1 class="text-xs flex flex-wrap py-1">

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
 </script>
 
-<h1 class="text-center text-xl">{$page.status} - {$page.error?.message}</h1>
+<h1 class="text-center text-xl">{page.status} - {page.error?.message}</h1>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,4 @@
-import { loadPreferences } from "$lib/preferences";
+import { loadPreferences } from "$lib/preferences.svelte";
 
 export const load: import("./$types").LayoutServerLoad = ({ cookies }) => {
   return {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { persistInitialPreferences } from "$lib/preferences";
+  import { contextifyPreferences } from "$lib/preferences.svelte";
   import "../app.css";
 
   const navLinks = [
@@ -18,7 +18,7 @@
 
   let { data, children }: Props = $props();
   // svelte-ignore state_referenced_locally
-  persistInitialPreferences(data.preferences);
+  contextifyPreferences(data.preferences);
 </script>
 
 <div class="container mx-auto px-2 py-4">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
   import { persistInitialPreferences } from "$lib/preferences";
   import "../app.css";
 
@@ -11,7 +11,13 @@
     ["/preferences", "Preferences"],
   ] as const;
 
-  export let data: import("./$types").LayoutServerData;
+  interface Props {
+    data: import("./$types").LayoutServerData;
+    children: import("svelte").Snippet;
+  }
+
+  let { data, children }: Props = $props();
+  // svelte-ignore state_referenced_locally
   persistInitialPreferences(data.preferences);
 </script>
 
@@ -25,7 +31,7 @@
         <li
           class="after:content-['•'] after:pl-2 after:pr-2 last:after:content-none"
         >
-          {#if url === $page.url.pathname}
+          {#if url === page.url.pathname}
             {text}{:else}
             <a
               class="text-cyan-700 dark:text-cyan-400"
@@ -35,9 +41,9 @@
                 // navigations. This is useful when moving back and forth
                 // between the main search and the repo search, or the main
                 // search and the query syntax page.
-                $page.route.id?.startsWith("/(opengrok-compat)/")
+                page.route.id?.startsWith("/(opengrok-compat)/")
                   ? ""
-                  : $page.url.search
+                  : page.url.search
               }`}>{text}</a
             >{/if}
         </li>
@@ -45,6 +51,6 @@
     </ul>
   </nav>
   <main>
-    <slot />
+    {@render children()}
   </main>
 </div>

--- a/src/routes/preferences/+page.svelte
+++ b/src/routes/preferences/+page.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
-  import {
-    acquireFileMatchesCutoffStore,
-    acquireMatchSortOrderStore,
-    acquireSearchTypeStore,
-    acquireOpenGrokInstantRedirectStore,
-  } from "$lib/preferences";
+  import { usePreferences } from "$lib/preferences.svelte";
   import IntegerInput from "$lib/integer-input.svelte";
 
-  const fileMatchesCutoff = acquireFileMatchesCutoffStore();
-  const matchSortOrder = acquireMatchSortOrderStore();
-  const searchType = acquireSearchTypeStore();
-  const openGrokInstantRedirect = acquireOpenGrokInstantRedirectStore();
+  const prefs = usePreferences();
 </script>
 
 <svelte:head>
@@ -32,7 +24,7 @@
             id="live"
             type="radio"
             name="search-type"
-            bind:group={$searchType}
+            bind:group={prefs.searchType}
             value="live"
           />
           Live as you type
@@ -44,7 +36,7 @@
             id="manual"
             type="radio"
             name="search-type"
-            bind:group={$searchType}
+            bind:group={prefs.searchType}
             value="manual"
           />
           Manual (hit enter to search)
@@ -59,7 +51,7 @@
             id="line-number"
             type="radio"
             name="sort"
-            bind:group={$matchSortOrder}
+            bind:group={prefs.matchSortOrder}
             value="line-number"
           />
           By line number
@@ -71,7 +63,7 @@
             id="score"
             type="radio"
             name="sort"
-            bind:group={$matchSortOrder}
+            bind:group={prefs.matchSortOrder}
             value="score"
           />
           By score according to zoekt
@@ -84,7 +76,7 @@
         <IntegerInput
           id="file-matches-cutoff"
           pending={false}
-          bind:value={$fileMatchesCutoff}
+          bind:value={prefs.fileMatchesCutoff}
         />
       </label>
     </div>
@@ -95,7 +87,7 @@
       <span class="text-lg">Redirects</span>
       <div>
         <label class="text-sm">
-          <input type="checkbox" bind:checked={$openGrokInstantRedirect} /> Automatically
+          <input type="checkbox" bind:checked={prefs.openGrokInstantRedirect} /> Automatically
           redirect from old OpenGrok URLs when possible.</label
         >
       </div>

--- a/src/routes/repositories/+page.svelte
+++ b/src/routes/repositories/+page.svelte
@@ -1,25 +1,33 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import type { ListResults } from "$lib/server/zoekt-list-repositories";
   import SearchForm from "./search-form.svelte";
   import RepositoriesList from "./repositories-list.svelte";
-  import { routeListQuery } from "./route-list-query";
+  import { parseSearchParams } from "./route-list-query";
 
-  export let data: import("./$types").PageData;
+  let routeListQuery = $derived(parseSearchParams(page.url.searchParams));
+
+  type Props = {
+    data: import("./$types").PageData;
+  };
+
+  let { data }: Props = $props();
 
   // Represents the last non-erroneous results, so that when we get an error,
   // we can display them instead of taking away all the results.
-  let previousListResults: ListResults | null = null;
-  $: {
+  let previousListResults: ListResults | null = $derived.by(() => {
     if (data.listOutcome.kind === "success") {
-      previousListResults = data.listOutcome.results;
+      return data.listOutcome.results;
+    } else {
+      return previousListResults;
     }
-  }
+  });
 </script>
 
 <svelte:head>
   <title
-    >{$routeListQuery.query
-      ? `${$routeListQuery.query} - `
+    >{routeListQuery.query
+      ? `${routeListQuery.query} - `
       : ""}neogrok/repositories</title
   >
 </svelte:head>

--- a/src/routes/repositories/branches.svelte
+++ b/src/routes/repositories/branches.svelte
@@ -3,8 +3,12 @@
   import type { Repository } from "$lib/server/zoekt-list-repositories";
   import { evaluateCommitUrlTemplate } from "$lib/url-templates";
 
-  export let branches: Repository["branches"];
-  export let commitUrlTemplate: string | undefined;
+  type Props = {
+    branches: Repository["branches"];
+    commitUrlTemplate: string | undefined;
+  };
+
+  let { branches, commitUrlTemplate }: Props = $props();
 
   // Abbreviate git hashes. Helps make the very wide table a bit narrower.
   const abbreviateVersion = (v: string) =>

--- a/src/routes/repositories/repositories-list.svelte
+++ b/src/routes/repositories/repositories-list.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import prettyBytes from "pretty-bytes";
+  import { page } from "$app/state";
   import type {
     ListResults,
     RepoStats,
@@ -8,36 +9,45 @@
   import Branches from "./branches.svelte";
   import Sortable from "./sortable-column-header.svelte";
   import { createComparator, type SortBy } from "./table-sorting";
-  import { routeListQuery } from "./route-list-query";
+  import { parseSearchParams } from "./route-list-query";
   import Link from "$lib/link.svelte";
 
-  export let results: ListResults;
+  let routeListQuery = $derived(parseSearchParams(page.url.searchParams));
 
-  let sortBy: SortBy | null = null;
-  $: sorted =
+  type Props = {
+    results: ListResults;
+  };
+
+  let { results }: Props = $props();
+
+  let sortBy: SortBy | null = $state(null);
+  let sorted = $derived(
     sortBy === null
       ? results.repositories
-      : Array.from(results.repositories).sort(createComparator(sortBy));
+      : Array.from(results.repositories).sort(createComparator(sortBy)),
+  );
 
-  $: truncated = sorted.slice(0, $routeListQuery.repos);
-  $: limited = results.repositories.length > $routeListQuery.repos;
-  $: truncatedStats = limited
-    ? truncated.reduce<RepoStats>(
-        (acc, val) => {
-          acc.shardCount += val.shardCount;
-          acc.fileCount += val.fileCount;
-          acc.indexBytes += val.indexBytes;
-          acc.contentBytes += val.contentBytes;
-          return acc;
-        },
-        {
-          shardCount: 0,
-          fileCount: 0,
-          indexBytes: 0,
-          contentBytes: 0,
-        },
-      )
-    : results.stats;
+  let truncated = $derived(sorted.slice(0, routeListQuery.repos));
+  let limited = $derived(results.repositories.length > routeListQuery.repos);
+  let truncatedStats = $derived(
+    limited
+      ? truncated.reduce<RepoStats>(
+          (acc, val) => {
+            acc.shardCount += val.shardCount;
+            acc.fileCount += val.fileCount;
+            acc.indexBytes += val.indexBytes;
+            acc.contentBytes += val.contentBytes;
+            return acc;
+          },
+          {
+            shardCount: 0,
+            fileCount: 0,
+            indexBytes: 0,
+            contentBytes: 0,
+          },
+        )
+      : results.stats,
+  );
 </script>
 
 <h1 class="text-xs flex flex-wrap py-1">

--- a/src/routes/repositories/repository-name.svelte
+++ b/src/routes/repositories/repository-name.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import Link from "$lib/link.svelte";
 
-  export let name: string;
-  export let url: string | undefined;
+  type Props = {
+    name: string;
+    url: string | undefined;
+  };
+
+  let { name, url }: Props = $props();
 </script>
 
 <div class="text-left">

--- a/src/routes/repositories/route-list-query.ts
+++ b/src/routes/repositories/route-list-query.ts
@@ -1,12 +1,11 @@
 import { goto } from "$app/navigation";
-import { navigating, page } from "$app/stores";
+import { navigating, page } from "$app/state";
 import type { SearchType } from "$lib/preferences";
 import type { ListQuery } from "$lib/server/zoekt-list-repositories";
-import { derived, get } from "svelte/store";
 
 const defaultQueryOptions: RouteListQuery = Object.freeze({ repos: 100 });
 
-type RouteListQuery = ListQuery & {
+export type RouteListQuery = ListQuery & {
   // This is only used in the frontend, there is no support for truncation in
   // the zoekt repositories list API, because there is no sorting.
   readonly repos: number;
@@ -27,10 +26,6 @@ export const parseSearchParams = (
   };
 };
 
-export const routeListQuery = derived(page, (p) =>
-  parseSearchParams(p.url.searchParams),
-);
-
 // This function is only called in the browser, so it's fine to have this be in
 // module state.
 let lastNavigateTime = 0;
@@ -49,7 +44,7 @@ export const updateRouteListQuery = ({
   // that we need to use the URL of where we're _going_ to be, not where we are,
   // as a baseline for comparison to decide if additional navigations are
   // needed.
-  const baselineUrl = get(navigating)?.to?.url ?? get(page).url;
+  const baselineUrl = navigating.to?.url ?? page.url;
   const listQuery = parseSearchParams(baselineUrl.searchParams);
 
   const queryChanged =

--- a/src/routes/repositories/route-list-query.ts
+++ b/src/routes/repositories/route-list-query.ts
@@ -1,6 +1,6 @@
 import { goto } from "$app/navigation";
 import { navigating, page } from "$app/state";
-import type { SearchType } from "$lib/preferences";
+import type { SearchType } from "$lib/preferences.svelte";
 import type { ListQuery } from "$lib/server/zoekt-list-repositories";
 
 const defaultQueryOptions: RouteListQuery = Object.freeze({ repos: 100 });

--- a/src/routes/repositories/search-form.svelte
+++ b/src/routes/repositories/search-form.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { navigating, page } from "$app/state";
-  import { acquireSearchTypeStore, type SearchType } from "$lib/preferences";
+  import { usePreferences, type SearchType } from "$lib/preferences.svelte";
   import { computeInputColor } from "$lib/input-colors";
   import { parseSearchParams, updateRouteListQuery } from "./route-list-query";
   import ToggleSearchType from "$lib/toggle-search-type.svelte";
@@ -15,7 +15,7 @@
 
   let { queryError }: Props = $props();
 
-  const searchType = acquireSearchTypeStore();
+  const prefs = usePreferences();
 
   // We need to do a complicated bidirectional mapping between the URL and the
   // form state. So, yes, this is intentional.
@@ -34,7 +34,7 @@
   });
 
   const shouldLiveSearch = () =>
-    $searchType === "live" &&
+    prefs.searchType === "live" &&
     // Same trigram efficiency rules as on the main search page.
     (!query || query.length >= 3);
 
@@ -42,17 +42,17 @@
     updateRouteListQuery({
       query,
       repos,
-      searchType: $searchType,
+      searchType: prefs.searchType,
     });
   };
 
   // When switching from manual to live search, submit any pending changes.
   let previousSearchType: SearchType | undefined = $state();
   $effect(() => {
-    if ($searchType === "live" && previousSearchType === "manual") {
+    if (prefs.searchType === "live" && previousSearchType === "manual") {
       manualSubmit();
     }
-    previousSearchType = $searchType;
+    previousSearchType = prefs.searchType;
   });
 
   // These all indicate when form changes with manual search are not yet submitted.
@@ -94,7 +94,7 @@
           bind:value={query}
           oninput={() => {
             if (shouldLiveSearch()) {
-              updateRouteListQuery({ query, searchType: $searchType });
+              updateRouteListQuery({ query, searchType: prefs.searchType });
             }
           }}
           id="query"
@@ -119,7 +119,7 @@
           if (shouldLiveSearch()) {
             updateRouteListQuery({
               repos: value,
-              searchType: $searchType,
+              searchType: prefs.searchType,
             });
           }
         }}

--- a/src/routes/repositories/search-form.svelte
+++ b/src/routes/repositories/search-form.svelte
@@ -113,6 +113,7 @@
       <span class="text-xs px-1 text-gray-500 dark:text-gray-400">repos</span>
       <IntegerInput
         id="context"
+        kind="positive"
         pending={reposPending}
         bind:value={repos}
         onChange={(value) => {

--- a/src/routes/repositories/search-form.svelte
+++ b/src/routes/repositories/search-form.svelte
@@ -1,29 +1,37 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
-  import { navigating } from "$app/stores";
+  import { navigating, page } from "$app/state";
   import { acquireSearchTypeStore, type SearchType } from "$lib/preferences";
   import { computeInputColor } from "$lib/input-colors";
-  import { routeListQuery, updateRouteListQuery } from "./route-list-query";
+  import { parseSearchParams, updateRouteListQuery } from "./route-list-query";
   import ToggleSearchType from "$lib/toggle-search-type.svelte";
   import LoadingEllipsis from "$lib/loading-ellipsis.svelte";
   import IntegerInput from "$lib/integer-input.svelte";
 
-  export let queryError: string | null;
+  let routeListQuery = $derived(parseSearchParams(page.url.searchParams));
+
+  type Props = {
+    queryError: string | null;
+  };
+
+  let { queryError }: Props = $props();
 
   const searchType = acquireSearchTypeStore();
 
-  let query: string | undefined;
-  let repos: number;
-  const unsubscribe = routeListQuery.subscribe((rq) => {
+  // We need to do a complicated bidirectional mapping between the URL and the
+  // form state. So, yes, this is intentional.
+  // svelte-ignore state_referenced_locally
+  let query: string | undefined = $state(routeListQuery.query);
+  // svelte-ignore state_referenced_locally
+  let repos: number = $state(routeListQuery.repos);
+  $effect(() => {
     // Sync form values with route state whenever a navigation _not_ related to
     // direct user interactions with the form.  Those are inherently already
     // covered by the relevant input bindings, and the resulting navigations
     // can conflict with those bindings.
-    if ($navigating?.type !== "goto") {
-      ({ query, repos } = rq);
+    if (navigating.type !== "goto") {
+      ({ query, repos } = routeListQuery);
     }
   });
-  onDestroy(unsubscribe);
 
   const shouldLiveSearch = () =>
     $searchType === "live" &&
@@ -39,22 +47,26 @@
   };
 
   // When switching from manual to live search, submit any pending changes.
-  let previousSearchType: SearchType | undefined;
-  $: {
+  let previousSearchType: SearchType | undefined = $state();
+  $effect(() => {
     if ($searchType === "live" && previousSearchType === "manual") {
       manualSubmit();
     }
     previousSearchType = $searchType;
-  }
+  });
 
   // These all indicate when form changes with manual search are not yet submitted.
-  $: queryPending =
-    $navigating === null && ($routeListQuery.query ?? "") !== (query ?? "");
-  $: reposPending = $navigating === null && $routeListQuery.repos !== repos;
+  let queryPending = $derived(
+    navigating.type === null && (routeListQuery.query ?? "") !== (query ?? ""),
+  );
+  let reposPending = $derived(
+    navigating.type === null && routeListQuery.repos !== repos,
+  );
 </script>
 
 <form
-  on:submit|preventDefault={() => {
+  onsubmit={(e) => {
+    e.preventDefault();
     manualSubmit();
   }}
 >
@@ -77,10 +89,10 @@
         )}`}
       >
         <!-- It's a search page, a11y be damned. cf. google.com, bing.com, etc. -->
-        <!-- svelte-ignore a11y-autofocus -->
+        <!-- svelte-ignore a11y_autofocus -->
         <input
           bind:value={query}
-          on:input={() => {
+          oninput={() => {
             if (shouldLiveSearch()) {
               updateRouteListQuery({ query, searchType: $searchType });
             }
@@ -103,10 +115,10 @@
         id="context"
         pending={reposPending}
         bind:value={repos}
-        on:change={(e) => {
+        onChange={(value) => {
           if (shouldLiveSearch()) {
             updateRouteListQuery({
-              repos: e.detail,
+              repos: value,
               searchType: $searchType,
             });
           }

--- a/src/routes/repositories/sortable-column-header.svelte
+++ b/src/routes/repositories/sortable-column-header.svelte
@@ -3,13 +3,18 @@
   import ChevronDown from "lucide-svelte/icons/chevron-down";
   import { nextSortBy, type SortColumn, type SortBy } from "./table-sorting";
 
-  export let sortColumn: SortColumn;
-  export let sortBy: SortBy | null;
+  type Props = {
+    sortColumn: SortColumn;
+    sortBy: SortBy | null;
+    children: import("svelte").Snippet;
+  };
+
+  let { sortColumn, sortBy = $bindable(), children }: Props = $props();
 </script>
 
 <button
   class="w-full h-full flex justify-center items-center hover:bg-slate-200 dark:hover:bg-slate-700"
-  on:click={() => {
+  onclick={() => {
     sortBy = nextSortBy(sortBy, sortColumn);
   }}
 >
@@ -21,5 +26,5 @@
   {:else}
     <ChevronDown class="flex-none" size={16} />
   {/if}
-  <span><slot /></span>
+  <span>{@render children()}</span>
 </button>


### PR DESCRIPTION
Switch to runes, and eliminate usage of stores. Plus, a few minor improvements to syntax highlighting. Some things in here were done with LLM assistance; there is a link to an amp thread for all such cases.